### PR TITLE
readme: Fix some bugs/omissions in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To use it, include this crate along with prost:
 prost = "0.9"
 prost-wkt = "0.2"
 prost-wkt-types = "0.2"
+serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
 prost-build = "0.9"
@@ -40,7 +41,7 @@ fn main() {
     prost_build
         .type_attribute(
             ".",
-            "#[derive(Serialize,Deserialize)] #[serde(default)]"
+            "#[derive(Serialize,Deserialize)]"
         )
         .extern_path(
             ".google.protobuf.Any",


### PR DESCRIPTION
When setting up prost-wkt, I found one bug and one omission in the
README examples.

The bug is that if you use the `#[serde(default)]` macro across
everything, any enums that you have won't compile because they don't
support this option.

The omission was that you need to have an explicit dependency on `serde`
with the derive feature enabled.