### PR TITLE
Switch to using `heck` for message formatting

### DIFF
--- a/example/build.rs
+++ b/example/build.rs
@@ -11,7 +11,11 @@ fn main() {
             "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default, rename_all=\"camelCase\")]",
         )
         .type_attribute(
-            ".my.messages.Foo",
+            ".my.messages.foo",
+            "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default, rename_all=\"camelCase\")]",
+        )
+        .type_attribute(
+            ".my.messages.Point2d",
             "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default, rename_all=\"camelCase\")]",
         )
         .type_attribute(

--- a/example/build.rs
+++ b/example/build.rs
@@ -11,11 +11,7 @@ fn main() {
             "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default, rename_all=\"camelCase\")]",
         )
         .type_attribute(
-            ".my.messages.foo",
-            "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default, rename_all=\"camelCase\")]",
-        )
-        .type_attribute(
-            ".my.messages.Point2d",
+            ".my.messages.Foo",
             "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default, rename_all=\"camelCase\")]",
         )
         .type_attribute(

--- a/wkt-build/Cargo.toml
+++ b/wkt-build/Cargo.toml
@@ -14,4 +14,5 @@ prost = "0.10.4"
 prost-types = "0.10.1"
 prost-build = "0.10.4"
 quote = "1.0"
-convert_case = "0.5"
+heck = "0.4"
+


### PR DESCRIPTION
This PR resolves #19 by switching to using the same formatting library (`heck`) that prost uses under the hood. Previously, message names such as `Point2d` would be converted to `Point2D`, causing compilation failures when using descriptors. 