### PR TITLE
Successful `Any::try_unpack()` without `#[serde(default)]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [ "wkt-build", "wkt-types", "example" ]
 
 [dependencies]
 prost = "0.11.0"
+inventory = "0.3.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate mopa;
 
+pub use inventory;
+
 pub use typetag;
 
 /// Trait to support serialization and deserialization of `prost` messages.
@@ -22,3 +24,12 @@ pub trait MessageSerde: prost::Message + mopa::Any {
 }
 
 mopafy!(MessageSerde);
+
+type MessageSerdeDecoderFn = fn(&[u8]) -> Result<Box<dyn MessageSerde>, ::prost::DecodeError>;
+
+pub struct MessageSerdeDecoderEntry {
+    pub type_url: &'static str,
+    pub decoder: MessageSerdeDecoderFn,
+}
+
+inventory::collect!(MessageSerdeDecoderEntry);

--- a/wkt-build/src/lib.rs
+++ b/wkt-build/src/lib.rs
@@ -86,6 +86,16 @@ fn gen_trait_impl(rust_file: &mut File, package_name: &str, message_name: &str, 
                     Ok(buf)
                 }
             }
+
+            ::prost_wkt::inventory::submit!{
+                ::prost_wkt::MessageSerdeDecoderEntry {
+                    type_url: #type_url,
+                    decoder: |buf: &[u8]| {
+                        let msg: #type_name = ::prost::Message::decode(buf)?;
+                        Ok(Box::new(msg))
+                    }
+                }
+            }
         };
     };
 

--- a/wkt-types/tests/pbany_test.rs
+++ b/wkt-types/tests/pbany_test.rs
@@ -58,6 +58,16 @@ impl prost_wkt::MessageSerde for Foo {
     }
 }
 
+::prost_wkt::inventory::submit!{
+    ::prost_wkt::MessageSerdeDecoderEntry {
+        type_url: "type.googleapis.com/any.test.Foo",
+        decoder: |buf: &[u8]| {
+            let msg: Foo = ::prost::Message::decode(buf)?;
+            Ok(Box::new(msg))
+        }
+    }
+}
+
 fn create_struct() -> Value {
     let number: Value = Value::from(10.0);
     let null: Value = Value::null();

--- a/wkt-types/tests/pbany_test.rs
+++ b/wkt-types/tests/pbany_test.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 #[derive(Clone, PartialEq, ::prost::Message, Serialize, Deserialize)]
 #[prost(package = "any.test")]
-#[serde(default, rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct Foo {
     #[prost(string, tag = "1")]
     pub string: std::string::String,


### PR DESCRIPTION
Closes #9

Current implementation uses `typetag`. Without any default values to initialize, the following code fails.

https://github.com/fdeantoni/prost-wkt/blob/94587de799050fdd4c251f34ec5600bbe0d133f4/wkt-types/src/pbany.rs#L115-L119

I use [the same mechanism used in `typetag`](https://docs.rs/typetag#so-many-questions) - using [`inventory`](https://docs.rs/inventory). But it expects `value` field to be serde (de)serializable.

This PR adds support for prost (de)serialization. 