### PR TITLE
Remove dependency on deprecated time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ inventory = "0.3.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 mopa = "0.2.2"
 typetag = "0.2"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -11,7 +11,7 @@ prost-wkt-types = { path = "../wkt-types" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 
 [build-dependencies]
 prost-build = "0.11.2"

--- a/wkt-types/Cargo.toml
+++ b/wkt-types/Cargo.toml
@@ -24,7 +24,7 @@ prost = "0.11.2"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 
 [build-dependencies]
 prost = "0.11.2"


### PR DESCRIPTION
## Background
The chrono version used here still supplies the `oldtime` feature, see [here](https://docs.rs/chrono/latest/chrono/#duration) for more information. It therefore depends on the deprecated time crate which contains a possible segfault. 

When running `cargo audit` on this projects or others implementing it you therefore get a warning.
```
Crate:     time
Version:   0.1.45
Title:     Potential segfault in the time crate
Date:      2020-11-18
ID:        RUSTSEC-2020-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution:  Upgrade to >=0.2.23
Dependency tree:
time 0.1.45
└── chrono 0.4.23
    ├── prost-wkt-types 0.3.4
    │   └── prost-wkt-example 0.3.4
    ├── prost-wkt-example 0.3.4
    └── prost-wkt 0.3.4
        ├── prost-wkt-types 0.3.4
        └── prost-wkt-example 0.3.4

error: 1 vulnerability found!
```

## Changes in this PR

To avoid the import of the `oldtime` feature all default features in `chrono` have been disabled. While the other features could be enabled again they appear not to be used. Getting rid of them has the additional benefit of reducing the size of this crate heavily. 

## Testing done with these changes
* Run `cargo test` and `cargo build`
* Used this crate in another project
  * Run `cargo test` 
  * Run `cargo build` which also builds protofiles using this crate

No testing produced any errors