### PR TITLE
Expose feature to compile with vendored protoc

### DIFF
--- a/wkt-types/Cargo.toml
+++ b/wkt-types/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 [features]
 default = ["std"]
 std = []
+vendored-protoc = ["protobuf-src"]
 
 [dependencies]
 prost-wkt = { version = "0.4.1", path = ".." }
@@ -32,3 +33,4 @@ prost-types = "0.11.5"
 prost-build = "0.11.5"
 prost-wkt-build = { version = "0.4.1", path = "../wkt-build" }
 regex = "1"
+protobuf-src = { version = "1.1.0", optional = true }

--- a/wkt-types/build.rs
+++ b/wkt-types/build.rs
@@ -11,6 +11,9 @@ use prost_types::FileDescriptorSet;
 use regex::Regex;
 
 fn main() {
+    #[cfg(feature = "vendored-protoc")]
+    std::env::set_var("PROTOC", protobuf_src::protoc());
+
     let dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     process_prost_pbtime(&dir);
 


### PR DESCRIPTION
In order to support building crates that depend on wkt-types that do not have protoc installed it is useful to enable using the vendored protoc.

closes https://github.com/fdeantoni/prost-wkt/issues/37