### PR TITLE
Allow Protox

### DIFF
--- a/wkt-types/Cargo.toml
+++ b/wkt-types/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 default = ["std"]
 std = []
 vendored-protoc = ["protobuf-src"]
+vendored-protox = ["protox"]
 
 [dependencies]
 prost-wkt = { version = "0.4.1", path = ".." }
@@ -34,3 +35,4 @@ prost-build = "0.11.5"
 prost-wkt-build = { version = "0.4.1", path = "../wkt-build" }
 regex = "1"
 protobuf-src = { version = "1.1.0", optional = true }
+protox = { version = "0.3.1", optional = true }

--- a/wkt-types/build.rs
+++ b/wkt-types/build.rs
@@ -29,6 +29,14 @@ fn build(dir: &Path, proto: &str) {
     let source = format!("proto/{proto}.proto");
     let descriptor_file = out.join("descriptors.bin");
     let mut prost_build = prost_build::Config::new();
+    
+    #[cfg(feature = "vendored-protox")]
+    {
+        let file_descriptors = protox::compile(&[source.clone()], &["proto/".to_string()]).unwrap();
+        std::fs::write(&descriptor_file, file_descriptors.encode_to_vec()).unwrap();
+        prost_build.skip_protoc_run();
+    }
+    
     prost_build
         .compile_well_known_types()
         .type_attribute("google.protobuf.Duration","#[derive(serde_derive::Serialize, serde_derive::Deserialize)] #[serde(default)]")


### PR DESCRIPTION
Adds an option to compile the protobuf files via [protox](https://crates.io/crates/protox) so that protoc is not required. This builds significantly faster than `libprotobuf` and should be another option.