### PR TITLE
Change parameter type of Any::try_pack.

### DIFF
--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), AnyError> {
     };
 
     let mut request: Request = Request::default();
-    let any = Any::try_pack(foo_msg)?;
+    let any = Any::try_pack(&foo_msg)?;
     request.request_id = "test1".to_string();
     request.payload = Some(any);
 

--- a/wkt-types/src/pbany.rs
+++ b/wkt-types/src/pbany.rs
@@ -72,11 +72,11 @@ impl Any {
     /// Packs a message into an `Any` containing a `type_url` which will take the format
     /// of `type.googleapis.com/package_name.struct_name`, and a value containing the
     /// encoded message.
-    pub fn try_pack<T>(message: T) -> Result<Self, AnyError>
+    pub fn try_pack<T>(message: &T) -> Result<Self, AnyError>
     where
         T: Message + MessageSerde + Default,
     {
-        let type_url = MessageSerde::type_url(&message).to_string();
+        let type_url = MessageSerde::type_url(message).to_string();
         // Serialize the message into a value
         let mut buf = Vec::new();
         buf.reserve(message.encoded_len());
@@ -207,7 +207,7 @@ mod tests {
         let msg = Foo {
             string: "Hello World!".to_string(),
         };
-        let any = Any::try_pack(msg.clone()).unwrap();
+        let any = Any::try_pack(&msg).unwrap();
         println!("{any:?}");
         let unpacked = any.unpack_as(Foo::default()).unwrap();
         println!("{unpacked:?}");
@@ -219,7 +219,7 @@ mod tests {
         let msg = Foo {
             string: "Hello World!".to_string(),
         };
-        let any = Any::try_pack(msg.clone()).unwrap();
+        let any = Any::try_pack(&msg).unwrap();
         println!("{any:?}");
         let unpacked: &dyn MessageSerde = &any.unpack_as(Foo::default()).unwrap();
         let downcast = unpacked.downcast_ref::<Foo>().unwrap();

--- a/wkt-types/tests/pbany_test.rs
+++ b/wkt-types/tests/pbany_test.rs
@@ -95,7 +95,7 @@ fn test_any_serialization() {
         boolean: true,
         value_data: Some(prost_wkt_types::Value::from("world".to_string())),
         list: vec!["one".to_string(), "two".to_string()],
-        payload: prost_wkt_types::Any::try_pack(inner).ok(),
+        payload: prost_wkt_types::Any::try_pack(&inner).ok(),
     };
     println!(
         "Serialized to string: {}",
@@ -150,7 +150,7 @@ fn test_any_serialize_deserialize() {
         boolean: true,
         value_data: Some(prost_wkt_types::Value::from("world".to_string())),
         list: vec!["one".to_string(), "two".to_string()],
-        payload: prost_wkt_types::Any::try_pack(inner).ok(),
+        payload: prost_wkt_types::Any::try_pack(&inner).ok(),
     };
 
     let json = serde_json::to_string(&original).unwrap();
@@ -171,7 +171,7 @@ fn test_any_unpack() {
         list: vec!["een".to_string(), "twee".to_string()],
         payload: None,
     };
-    let any = prost_wkt_types::Any::try_pack(payload).unwrap();
+    let any = prost_wkt_types::Any::try_pack(&payload).unwrap();
     let unpacked = any.try_unpack().unwrap();
     let foo = unpacked.downcast_ref::<Foo>().unwrap();
     println!("Unpacked: {foo:?}");


### PR DESCRIPTION
Implements #48.
This is a breaking change, which might be undesired.
A possible workaround would be to implement a new function called `try_pack_by_ref(&T)` alongside with current `try_pack(T)`.