### PR TITLE
Fix deprecated use of DateTime::from_utc()

### DIFF
--- a/wkt-types/src/pbtime.rs
+++ b/wkt-types/src/pbtime.rs
@@ -42,7 +42,7 @@ impl From<Timestamp> for DateTime<Utc> {
         value.normalize();
         let dt = NaiveDateTime::from_timestamp_opt(value.seconds, value.nanos as u32)
             .expect("invalid or out-of-range datetime");
-        DateTime::from_utc(dt, Utc)
+        DateTime::from_naive_utc_and_offset(dt, Utc)
     }
 }
 


### PR DESCRIPTION
DateTime::from_utc() has been deprecated since chrono@0.4.27. The deprecation note states: `Use TimeZone::from_utc_datetime() or DateTime::from_naive_utc_and_offset instead`.