### PR TITLE
Use an anonymous const rather than a dummy name

### DIFF
--- a/wkt-build/src/lib.rs
+++ b/wkt-build/src/lib.rs
@@ -1,4 +1,4 @@
-use heck::{ToShoutySnakeCase, ToUpperCamelCase};
+use heck::ToUpperCamelCase;
 use quote::{format_ident, quote};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
@@ -47,14 +47,9 @@ fn gen_trait_impl(rust_file: &mut File, package_name: &str, message_name: &str, 
     let type_name = message_name.to_upper_camel_case();
     let type_name = format_ident!("{}", type_name);
 
-    let dummy_const = format_ident!(
-        "IMPL_MESSAGE_SERDE_FOR_{}",
-        message_name.to_shouty_snake_case()
-    );
-
     let tokens = quote! {
         #[allow(dead_code)]
-        const #dummy_const: () = {
+        const _: () = {
             use ::prost_wkt::typetag;
             #[typetag::serde(name=#type_url)]
             impl ::prost_wkt::MessageSerde for #type_name {


### PR DESCRIPTION
Running on the nightly compiler produced this warning for us:

```
warning: non-local `impl` definition, they should be avoided as they go against expectation
    --> /Users/mtanous/src/github.com/Shopify/shopify-cdp/grpc/target/debug/build/shopify-cdp-grpc-663ae16d1a1bc1bf/out/shopify.cdp.v1.rs:6495:1347
     |
6495 | ...st IMPL_MESSAGE_SERDE_FOR_NODE : () = { use :: prost_wkt :: typetag ; # [typetag :: serde (name = "type.googleapis.com/shopify.cdp.v1.Node")] impl :: prost_wkt :: MessageSerde for Node { fn package_name (& self) -> & 'static str { "shopify.cdp.v1" } fn message_name (& self) -> & 'static str { "Node" } fn type_url (& self) -> & 'static str { "type.googleapis.com/shopify.cdp.v1.Node" } fn new_instance (& self , data : Vec < u8 >) -> :: std :: result :: Result < Box < dyn :: prost_wkt :: MessageSerde > , :: prost :: DecodeError > { let mut target = Self :: default () ; :: prost :: Message :: merge (& mut target , data . as_slice ()) ? ; let erased : :: std :: boxed :: Box < dyn :: prost_wkt :: MessageSerde > = :: std :: boxed :: Box :: new (target) ; Ok (erased) } fn try_encoded (& self) -> :: std :: result :: Result < :: std :: vec :: Vec < u8 > , :: prost :: EncodeError > { let mut buf = :: std :: vec :: Vec :: with_capacity (:: prost :: Message :: encoded_len (self)) ; :: prost :: Message :: encode (self , & mut buf) ? ; Ok (buf) } } :: prost_wkt :: inventory :: submit ! { :: prost_wkt :: MessageSerdeDecoderEntry { type_url : "type.googleapis.com/shopify.cdp.v1.Node" , decoder : | buf : & [u8] | { let msg : Node = :: prost :: Message :: decode (buf) ? ; Ok (:: std :: boxed :: Box :: new (msg)) } } } impl :: prost :: Name for Node { const PACKAGE : & 'static str = "shopify.cdp.v1" ; const NAME : & 'static str = "Node" ; fn type_url () -> String { "type.googleapis.com/shopify.cdp.v1.Node" . to_string () } } ...
     |       --------------------------- help: use a const-anon item to suppress this lint: `_`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: move this `impl` block outside the of the current constant `IMPL_MESSAGE_SERDE_FOR_NODE`
     = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
     = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
     = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
```
     
As noted in the linter warning, the exception to the rule on this lint is an `anon-const`. This small PR updates from using `IMPL_MESSAGE_SERDE_FOR_{}` to just the anon-const `_` for the const block that defines the `impl`.
     
I've validated that this still works in our codebase and does not throw the linter warning. The impetus here is to pave the way for `this lint may become deny-by-default in the edition 2024` so when we (and other folks) transition, we don't get errors.