### PR TITLE
Upgrade prost crates to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.70"
 members = [ "wkt-build", "wkt-types", "example" ]
 
 [dependencies]
-prost = "0.12.3"
+prost = "0.13"
 inventory = "0.3.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 rust-version = "1.70"
 
 [dependencies]
-prost = "0.12.3"
+prost = "0.13"
 prost-wkt = { path = ".." }
 prost-wkt-types = { path = "../wkt-types" }
 serde = "1.0"
@@ -15,5 +15,5 @@ serde_json = "1.0"
 chrono = { version = "0.4.27", default-features = false, features = ["clock", "serde"] }
 
 [build-dependencies]
-prost-build = "0.12.3"
+prost-build = "0.13"
 prost-wkt-build = { path = "../wkt-build" }

--- a/wkt-build/Cargo.toml
+++ b/wkt-build/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2021"
 rust-version = "1.70"
 
 [dependencies]
-prost = "0.12.3"
-prost-types = "0.12.3"
-prost-build = "0.12.3"
+prost = "0.13"
+prost-types = "0.13"
+prost-build = "0.13"
 quote = "1.0"
 heck = { version = ">=0.4, <=0.5" }

--- a/wkt-types/Cargo.toml
+++ b/wkt-types/Cargo.toml
@@ -23,16 +23,16 @@ vendored-protox = ["protox"]
 
 [dependencies]
 prost-wkt = { version = "0.5.1", path = ".." }
-prost = "0.12.3"
+prost = "0.13"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 chrono = { version = "0.4.27", default-features = false, features = ["serde"] }
 
 [build-dependencies]
-prost = "0.12.3"
-prost-types = "0.12.3"
-prost-build = "0.12.3"
+prost = "0.13"
+prost-types = "0.13"
+prost-build = "0.13"
 prost-wkt-build = { version = "0.5.1", path = "../wkt-build" }
 regex = "1"
 protobuf-src = { version = "1.1.0", optional = true }


### PR DESCRIPTION
Upgrade to the latest `prost` version (`0.13`):

- https://crates.io/crates/prost
- https://crates.io/crates/prost-types
- https://crates.io/crates/prost-build

Closes https://github.com/fdeantoni/prost-wkt/issues/67