### PR TITLE
bump protox version to match `prost` version being used.

### DIFF
--- a/wkt-types/Cargo.toml
+++ b/wkt-types/Cargo.toml
@@ -36,4 +36,4 @@ prost-build = "0.13.1"
 prost-wkt-build = { version = "0.6.0", path = "../wkt-build" }
 regex = "1"
 protobuf-src = { version = "1.1.0", optional = true }
-protox = { version = "0.6.0", optional = true }
+protox = { version = "0.7.0", optional = true }


### PR DESCRIPTION
Bump protox version to match `prost` version being used.
- `wkt-types` is using `prost@0.13.1` which means in order to build with `protox`, the `protox` version must also be using `>=prost@0.13.0`
- https://github.com/andrewhickman/protox/blob/main/protox/Cargo.toml