### PR TITLE
Upgrade protobuf-src from 1.1.0 to 2.1.0

### DIFF
--- a/wkt-types/Cargo.toml
+++ b/wkt-types/Cargo.toml
@@ -35,5 +35,5 @@ prost-types = "0.13.1"
 prost-build = "0.13.1"
 prost-wkt-build = { version = "0.6.0", path = "../wkt-build" }
 regex = "1"
-protobuf-src = { version = "1.1.0", optional = true }
+protobuf-src = { version = "2.1.0", optional = true }
 protox = { version = "0.6.0", optional = true }


### PR DESCRIPTION
Upgrade protobuf-src from 1.1.0 to 2.1.0

A changelog is present [here](https://github.com/MaterializeInc/rust-protobuf-native/blob/master/protobuf-src/CHANGELOG.md),

**Key benefit**
 - Upgrades libprotobuf from v21.5 to v27.2