### PR TITLE
Add Schemars Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ and that it can be deserialized as well.
 
 See the `example` sub-project for a fully functioning example.
 
+## Schemars ##
+This crate is compatible with [schemars](https://github.com/GREsau/schemars) if the feature `schemars` is enabled:
+
+```toml
+[dependencies]
+prost-wkt-types = { version = "0.6", features = ["schemars"] }
+```
+
+This will derive the [JsonSchema](https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html) trait for the types in this crate so they can be used to generate JSON schema files.
+
 ## Known Problems ##
 
 ### oneOf types ###

--- a/wkt-types/Cargo.toml
+++ b/wkt-types/Cargo.toml
@@ -28,6 +28,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 chrono = { version = "0.4.27", default-features = false, features = ["serde"] }
+schemars = { version = "0.8", optional = true }
 
 [build-dependencies]
 prost = "0.13.1"

--- a/wkt-types/src/pbany.rs
+++ b/wkt-types/src/pbany.rs
@@ -179,6 +179,53 @@ impl<'de> Deserialize<'de> for Any {
     }
 }
 
+#[cfg(feature = "schemars")]
+mod schemars_impl {
+    use super::Any;
+    use std::borrow::Cow;
+    use schemars::{JsonSchema, Set};
+    use schemars::gen::SchemaGenerator;
+    use schemars::schema::{InstanceType, Schema, SchemaObject};
+
+    impl JsonSchema for Any {
+        fn schema_name() -> String {
+            "Any".to_string()
+        }
+
+        fn schema_id() -> Cow<'static, str> {
+            Cow::Borrowed("prost_wkt_types::Any")
+        }
+
+        fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+            let mut schema = SchemaObject {
+                instance_type: Some(InstanceType::Object.into()),
+                ..Default::default()
+            };
+
+            schema.metadata().description = Some("Represents a dynamically typed protocol buffer message".to_string());
+            schema.metadata().examples = vec![serde_json::json!({
+                "@type": "type.googleapis.com/google.protobuf.Duration",
+                "value": "1.5s"
+            })];
+
+            let mut properties = schemars::Map::new();
+            properties.insert("@type".to_string(), SchemaObject {
+                instance_type: Some(InstanceType::String.into()),
+                ..Default::default()
+            }.into());
+            properties.insert("value".to_string(), SchemaObject {
+                instance_type: Some(InstanceType::String.into()),
+                ..Default::default()
+            }.into());
+
+            schema.object().properties = properties;
+            schema.object().required = Set::from(["@type".to_string(), "value".to_string()]);
+
+            Schema::Object(schema)
+        }
+    }
+}
+
 /// URL/resource name that uniquely identifies the type of the serialized protocol buffer message,
 /// e.g. `type.googleapis.com/google.protobuf.Duration`.
 ///

--- a/wkt-types/src/pbempty.rs
+++ b/wkt-types/src/pbempty.rs
@@ -8,6 +8,36 @@ impl From<()> for Empty {
     }
 }
 
+#[cfg(feature = "schemars")]
+mod schemars_impl {
+    use super::Empty;
+    use std::borrow::Cow;
+    use schemars::JsonSchema;
+    use schemars::gen::SchemaGenerator;
+    use schemars::schema::{InstanceType, Schema, SchemaObject};
+
+    impl JsonSchema for Empty {
+        fn schema_name() -> String {
+            "Empty".to_string()
+        }
+
+        fn schema_id() -> Cow<'static, str> {
+            Cow::Borrowed("prost_wkt_types::Empty")
+        }
+
+        fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+            let mut schema = SchemaObject {
+                instance_type: Some(InstanceType::Object.into()),
+                ..Default::default()
+            };
+
+            schema.metadata().description = Some("Represents an empty message".to_string());
+
+            Schema::Object(schema)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/wkt-types/src/pbtime/duration.rs
+++ b/wkt-types/src/pbtime/duration.rs
@@ -277,5 +277,39 @@ impl<'de> Deserialize<'de> for Duration {
     }
 }
 
+#[cfg(feature = "schemars")]
+mod schemars_impl {
+    use super::Duration;
+    use std::borrow::Cow;
+    use schemars::JsonSchema;
+    use schemars::gen::SchemaGenerator;
+    use schemars::schema::{InstanceType, Schema, SchemaObject};
 
+    impl JsonSchema for Duration {
+        fn schema_name() -> String {
+            "Duration".to_string()
+        }
 
+        fn schema_id() -> Cow<'static, str> {
+            Cow::Borrowed("prost_wkt_types::Duration")
+        }
+
+        fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+            let mut schema = SchemaObject {
+                instance_type: Some(InstanceType::String.into()),
+                ..Default::default()
+            };
+
+            schema.metadata().description = Some("A duration in seconds with up to nine fractional digits, ending with 's'".to_string());
+            schema.metadata().examples = vec![
+                serde_json::json!("1s"),
+                serde_json::json!("1.5s"),
+                serde_json::json!("1.000000001s"),
+            ];
+
+            schema.string().pattern = Some(r"^\d+(\.\d{1,9})?s$".to_string());
+
+            Schema::Object(schema)
+        }
+    }
+}

--- a/wkt-types/src/pbtime/timestamp.rs
+++ b/wkt-types/src/pbtime/timestamp.rs
@@ -321,3 +321,36 @@ impl<'de> Deserialize<'de> for Timestamp {
     }
 }
 
+#[cfg(feature = "schemars")]
+mod schemars_impl {
+    use super::Timestamp;
+    use std::borrow::Cow;
+    use schemars::JsonSchema;
+    use schemars::gen::SchemaGenerator;
+    use schemars::schema::{InstanceType, Schema, SchemaObject};
+
+    impl JsonSchema for Timestamp {
+        fn schema_name() -> String {
+            "Timestamp".to_string()
+        }
+
+        fn schema_id() -> Cow<'static, str> {
+            Cow::Borrowed("prost_wkt_types::Timestamp")
+        }
+
+        fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+            let mut schema = SchemaObject {
+                instance_type: Some(InstanceType::String.into()),
+                ..Default::default()
+            };
+
+            schema.metadata().description = Some("A timestamp in RFC 3339 format".to_string());
+            schema.metadata().examples = vec![
+                serde_json::json!("2025-04-11T12:00:00Z"),
+                serde_json::json!("2025-04-11T12:00:00.123456789Z"),
+            ];
+
+            Schema::Object(schema)
+        }
+    }
+}


### PR DESCRIPTION
Adds implementations of the schemars trait for Duration, Timestamp, Any and Empty to make it easy to generate json schemas for these types. This is kept behind the schemars flag to make this an optional dependency.