### PR TITLE
Prost 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.71.1"
 members = [ "wkt-build", "wkt-types", "example" ]
 
 [dependencies]
-prost = "0.13.1"
+prost = "0.14.1"
 inventory = "0.3.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ To use it, include this crate along with prost:
 
 ```toml
 [dependencies]
-prost = "0.13"
+prost = "0.14"
 prost-wkt = "0.6"
 prost-wkt-types = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-prost-build = "0.13"
+prost-build = "0.14"
 prost-wkt-build = "0.6"
 ```
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 rust-version = "1.71.1"
 
 [dependencies]
-prost = "0.13.1"
+prost = "0.14.1"
 prost-wkt = { path = ".." }
 prost-wkt-types = { path = "../wkt-types" }
 serde = "1.0"
@@ -15,5 +15,5 @@ serde_json = "1.0"
 chrono = { version = "0.4.27", default-features = false, features = ["clock", "serde"] }
 
 [build-dependencies]
-prost-build = "0.13.1"
+prost-build = "0.14.1"
 prost-wkt-build = { path = "../wkt-build" }

--- a/wkt-build/Cargo.toml
+++ b/wkt-build/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2021"
 rust-version = "1.71.1"
 
 [dependencies]
-prost = "0.13.1"
-prost-types = "0.13.1"
-prost-build = "0.13.1"
+prost = "0.14.1"
+prost-types = "0.14.1"
+prost-build = "0.14.1"
 quote = "1.0"
 heck = { version = ">=0.4, <=0.5" }

--- a/wkt-types/Cargo.toml
+++ b/wkt-types/Cargo.toml
@@ -23,7 +23,7 @@ vendored-protox = ["protox"]
 
 [dependencies]
 prost-wkt = { version = "0.6.1", path = ".." }
-prost = "0.13.1"
+prost = "0.14.1"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
@@ -31,10 +31,10 @@ chrono = { version = "0.4.27", default-features = false, features = ["serde"] }
 schemars = { version = "0.8", optional = true }
 
 [build-dependencies]
-prost = "0.13.1"
-prost-types = "0.13.1"
-prost-build = "0.13.1"
+prost = "0.14.1"
+prost-types = "0.14.1"
+prost-build = "0.14.1"
 prost-wkt-build = { version = "0.6.1", path = "../wkt-build" }
 regex = "1"
 protobuf-src = { version = "2.1.0", optional = true }
-protox = { version = "0.7.0", optional = true }
+protox = { version = "0.9.0", optional = true }

--- a/wkt-types/src/pbtime/duration.rs
+++ b/wkt-types/src/pbtime/duration.rs
@@ -4,14 +4,6 @@ use super::*;
 /// FROM prost-types/src/duration.rs
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(feature = "std")]
-impl std::hash::Hash for Duration {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.seconds.hash(state);
-        self.nanos.hash(state);
-    }
-}
-
 impl Duration {
     /// Normalizes the duration to a canonical format.
     ///

--- a/wkt-types/src/pbtime/timestamp.rs
+++ b/wkt-types/src/pbtime/timestamp.rs
@@ -116,19 +116,6 @@ impl Timestamp {
 //     }
 // }
 
-/// Implements the unstable/naive version of `Eq`: a basic equality check on the internal fields of the `Timestamp`.
-/// This implies that `normalized_ts != non_normalized_ts` even if `normalized_ts == non_normalized_ts.normalized()`.
-#[cfg(feature = "std")]
-impl Eq for Timestamp {}
-
-#[cfg(feature = "std")]
-impl std::hash::Hash for Timestamp {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.seconds.hash(state);
-        self.nanos.hash(state);
-    }
-}
-
 #[cfg(feature = "std")]
 impl From<std::time::SystemTime> for Timestamp {
     fn from(system_time: std::time::SystemTime) -> Timestamp {


### PR DESCRIPTION
Updates to Prost 0.14, removing a couple trait implementations that are now generated automatically