### PR TITLE
Raise the minimum Rust version to `1.85`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
           - windows-latest
         rust:
           - stable
-          - 1.82
+          - 1.85
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [ "wkt", "wkt-build", "wkt-types", "example" ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 version = "0.7.1"
@@ -11,7 +11,7 @@ description = "Helper crate for prost to allow JSON serialization and deserializ
 readme = "README.md"
 documentation = "https://docs.rs/prost-wkt-derive"
 edition = "2021"
-rust-version = "1.82"
+rust-version = "1.85"
 
 [workspace.dependencies]
 prost = "0.14.1"

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ When upgrading Prost to the latest version, make sure the latest changes from `p
 
 ## MSRV ##
 
-The minimum supported Rust version is Rust 1.82.
+The minimum supported Rust version is Rust 1.85.
 
 ## License ##
 


### PR DESCRIPTION
CI has been red on `master` since dependency versions drifted past the declared minimum Rust. Nothing records which versions to use, so every run resolves to the newest, and `prost 0.14.4` together with `indexmap 2.14.0` and `hashbrown 0.17.1` now need 1.85. Unchanged `master` fails the same way on cargo 1.82 locally and builds on 1.85, so this is not specific to any open PR.

Raising the floor fixes it today. The `resolver = "3"` line is what stops it happening again.